### PR TITLE
Add sitemap generating events from 1.9.0.1

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Sitemap/Sitemap.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Sitemap/Sitemap.php
@@ -29,7 +29,12 @@ class Creare_CreareSeoCore_Model_Sitemap_Sitemap extends Mage_Sitemap_Model_Site
         $changefreq = (string)Mage::getStoreConfig('sitemap/category/changefreq', $storeId);
         $priority   = (string)Mage::getStoreConfig('sitemap/category/priority', $storeId);
         $collection = Mage::getResourceModel('sitemap/catalog_category')->getCollection($storeId);
-        foreach ($collection as $item) {
+        $categories = new Varien_Object();
+        $categories->setItems($collection);
+        Mage::dispatchEvent('sitemap_categories_generating_before', array(
+            'collection' => $categories
+        ));
+        foreach ($categories->getItems() as $item) {
             $xml = sprintf(
                 '<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
                 htmlspecialchars($baseUrl . $item->getUrl()),
@@ -47,7 +52,12 @@ class Creare_CreareSeoCore_Model_Sitemap_Sitemap extends Mage_Sitemap_Model_Site
         $changefreq = (string)Mage::getStoreConfig('sitemap/product/changefreq', $storeId);
         $priority   = (string)Mage::getStoreConfig('sitemap/product/priority', $storeId);
         $collection = Mage::getResourceModel('sitemap/catalog_product')->getCollection($storeId);
-        foreach ($collection as $item) {
+        $products = new Varien_Object();
+        $products->setItems($collection);
+        Mage::dispatchEvent('sitemap_products_generating_before', array(
+            'collection' => $products
+        ));
+        foreach ($products->getItems() as $item) {
             $xml = sprintf(
                 '<url><loc>%s</loc><lastmod>%s</lastmod><changefreq>%s</changefreq><priority>%.1f</priority></url>',
                 htmlspecialchars($baseUrl . $item->getUrl()),


### PR DESCRIPTION
In 1.9.0.1 two events were added to Sitemap/Model/Sitemap.php generateXml():

sitemap_categories_generating_before
sitemap_products_generating_before

They allow the respective collections to be modified before the xml is created.
This patch copies those events into Creare_CreareSeoCore_Model_Sitemap_Sitemap.
