### PR TITLE
OG/Twitter Card now gets full size product img

### DIFF
--- a/app/design/frontend/base/default/template/creareseo/social/social.phtml
+++ b/app/design/frontend/base/default/template/creareseo/social/social.phtml
@@ -11,7 +11,7 @@ if($_product):
 <meta name="twitter:creator" content="@<?php echo Mage::getStoreConfig('creareseocore/social/twittercreator') ?>" />
 <meta name="twitter:title" content="<?php echo $_product->getName() ?>" />
 <meta name="twitter:description" content="<?php echo strip_tags ($_helper->productAttribute($_product, nl2br($_product->getShortDescription()), 'short_description')) ?>" />
-<meta name="twitter:image" content="<?php echo $_product->getImageUrl() ?>" />
+<meta name="twitter:image" content="<?php echo Mage::getModel('catalog/product_media_config')->getMediaUrl($_product->getImage()) ?>" />
 <meta name="twitter:data1" content="<?php echo $currency.Mage::helper('tax')->getPrice($_product, $_product->getFinalPrice(), true); ?>" />
 <meta name="twitter:label1" content="PRICE" />
 <meta name="twitter:data2" content="<?php echo Mage::getStoreConfig('shipping/origin/country_id') ?>" />
@@ -20,7 +20,7 @@ if($_product):
 <meta property="og:site_name" content="<?php echo Mage::app()->getStore()->getName(); ?>" />
 <meta property="og:type" content="og:product" />
 <meta property="og:title" content="<?php echo $_product->getName() ?>" />
-<meta property="og:image" content="<?php echo $_product->getImageUrl() ?>" />
+<meta property="og:image" content="<?php echo Mage::getModel('catalog/product_media_config')->getMediaUrl($_product->getImage()) ?>" />
 <meta property="og:description" content="<?php echo strip_tags ($_helper->productAttribute($_product, nl2br($_product->getShortDescription()), 'short_description')) ?>" />
 <meta property="og:url" content="<?php echo $_product->getUrlModel()->getUrl($_product, array('_ignore_category' => true)) ?>" />
 <meta property="og:price:amount" content="<?php echo number_format($_product->getFinalPrice(),2) ?>" />


### PR DESCRIPTION
OG/Twitter Card now gets full size product img instead of resized frontend img

as suggested by Facebook and Twitter... they will do proper resizing for their needs
https://dev.twitter.com/cards/types/photo
https://developers.facebook.com/docs/sharing/best-practices#images

Appriciate your work, want to give at least something little back ;)
