### PR TITLE
Fix for compatibility with SUPEE-8788

### DIFF
--- a/app/design/adminhtml/default/default/template/creareseo/catalog/product/helper/gallery.phtml
+++ b/app/design/adminhtml/default/default/template/creareseo/catalog/product/helper/gallery.phtml
@@ -82,6 +82,7 @@ $_block = $this;
     <tfoot>
         <tr>
             <td colspan="100" class="last" style="padding:8px">
+		<?php echo Mage::helper('catalog')->__('Maximum width and height dimension for upload image is %s.', Mage::getStoreConfig(Mage_Catalog_Helper_Image::XML_NODE_PRODUCT_MAX_DIMENSION)); ?>
                 <?php echo $_block->getUploaderHtml() ?>
             </td>
         </tr>
@@ -94,6 +95,6 @@ $_block = $this;
 <input type="hidden" id="<?php echo $_block->getHtmlId() ?>_save_image" name="<?php echo $_block->getElement()->getName() ?>[values]" value="<?php echo $_block->escapeHtml($_block->getImagesValuesJson()) ?>" />
 <script type="text/javascript">
 //<![CDATA[
-var <?php echo $_block->getJsObjectName(); ?> = new Product.Gallery('<?php echo $_block->getHtmlId() ?>', <?php if ($_block->getElement()->getReadonly()):?>null<?php else:?><?php echo $_block->getUploader()->getJsObjectName() ?><?php endif;?>, <?php echo $_block->getImageTypesJson() ?>);
+var <?php echo $_block->getJsObjectName(); ?> = new Product.Gallery('<?php echo $_block->getHtmlId() ?>', <?php echo $_block->getImageTypesJson() ?>);
 //]]>
 </script>


### PR DESCRIPTION
The SUPEE-8788 patch adds a new uploader which removes Flash from the admin catalog image upload functionality. Because CreareSEO overrides the template, the uploader is broken after applying the patch. I've adjusted the template to incorporate the patch adjustments. 