### PR TITLE
escape URL before comparing with an escaped URL (#79)

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -186,7 +186,7 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract {
                 // Maintain querystring if one is set (to maintain tracking URLs such as gclid)
                 $querystring = ($_SERVER['QUERY_STRING'] ? '?'.$_SERVER['QUERY_STRING'] : '');
                 $product = $observer->getEvent()->getProduct();
-                $url = $product->getUrlModel()->getUrl($product, array('_ignore_category'=>true)).$querystring;
+                $url = Mage::helper('core/url')->escapeUrl($product->getUrlModel()->getUrl($product, array('_ignore_category'=>true)).$querystring);
                 if(Mage::helper('core/url')->getCurrentUrl() != $url){
                     Mage::app()->getFrontController()->getResponse()->setRedirect($url,301);
                     Mage::app()->getResponse()->sendResponse();


### PR DESCRIPTION
URL comparison is failing, which is causing a recursive redirect.