### PR TITLE
Fix for product urls with trailing slashes

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Helper/Data.php
+++ b/app/code/community/Creare/CreareSeoCore/Helper/Data.php
@@ -17,10 +17,10 @@ class Creare_CreareSeoCore_Helper_Data extends Mage_Core_Helper_Abstract
             $cats = $product->getCategoryIds();
             if (is_array($cats) && count($cats) > 1) {
                 $cat = Mage::getModel('catalog/category')->load( $cats[0] ); 
-                return $cat->getUrlPath();
+                return Mage::getUrl($cat->getUrlPath());
             } else {
                 $cat = Mage::getModel('catalog/category')->load( $cats ); 
-                return $cat->getUrlPath();
+                return Mage::getUrl($cat->getUrlPath());
             }
         }
 


### PR DESCRIPTION
If product urls contains trailing slashes, the resulting redirects is "domain.com/product-url/category-path" instead of "domain.com/category-path". All other types return full URL, the category redirect type returns full url now too