### PR TITLE
fixed isHomePage check

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Block/Page/Html/Head/Cmscanonical.php
+++ b/app/code/community/Creare/CreareSeoCore/Block/Page/Html/Head/Cmscanonical.php
@@ -5,7 +5,7 @@ class Creare_CreareSeoCore_Block_Page_Html_Head_Cmscanonical extends Mage_Core_B
     public function getCanonicalUrl()
     {
         $cmsPagePath = Mage::getSingleton('cms/page')->getIdentifier();
-        $isHomePage = $this->getUrl('') == $this->getUrl('*/*/*', array('_current'=>true, '_use_rewrite'=>true));
+        $isHomePage = Mage::app()->getFrontController()->getAction()->getFullActionName() == 'cms_index_index';
         if($isHomePage){
 			$canonicalUrl = Mage::getBaseUrl();
 		} else {


### PR DESCRIPTION
Before, the homepage was checked via:

    $this->getUrl('') == $this->getUrl('*/*/*', array('_current'=>true, '_use_rewrite'=>true));

Although this is the "official" code as in `Mage_Page_Block_Html_Header::getIsHomePage`, this is buggy. It returns false if you hit the homepage with a parameter like `https://www.site.com/?__from_store=de`. The full action name should be a better way of checking I think.