### PR TITLE
getDiscontinuedCategoryUrl now checks to see if category parent exists

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Helper/Data.php
+++ b/app/code/community/Creare/CreareSeoCore/Helper/Data.php
@@ -57,7 +57,7 @@ class Creare_CreareSeoCore_Helper_Data extends Mage_Core_Helper_Abstract
             } else {
                 return Mage::getBaseUrl().$category->getUrlPath();
             }
-        } else {
+        } else if ($category->getParentId()) {
             $parentCategory = Mage::getModel('catalog/category')->load($category->getParentId());
             return $this->getDiscontinuedCategoryUrl($parentCategory);
         }


### PR DESCRIPTION
I had an issue on a site where the category no longer existed, this caused a 502 error when google crawled the old category, as it caused an infinite loop since the else statement calls it's own method. 

It should be returning a 404. 

I've changed line 60 to an if else statement so if a category does not have a parent Id, it doesn't call it's own method again.