### PR TITLE
removed useless condition

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -185,19 +185,16 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract
     
     public function forceProductCanonical(Varien_Event_Observer $observer)
     {
-        if (Mage::getStoreConfig('catalog/seo/product_canonical_tag') && !Mage::getStoreConfig('product_use_categories'))
-        {
-            if ($this->helper->getConfig('forcecanonical')) {
-                // check for normal catalog/product/view controller here
-                if(!stristr("catalog",Mage::app()->getRequest()->getModuleName()) && Mage::app()->getRequest()->getControllerName() != "product") return;
-                // Maintain querystring if one is set (to maintain tracking URLs such as gclid)
-                $querystring = ($_SERVER['QUERY_STRING'] ? '?'.$_SERVER['QUERY_STRING'] : '');
-                $product = $observer->getEvent()->getProduct();
-                $url = Mage::helper('core/url')->escapeUrl($product->getUrlModel()->getUrl($product, array('_ignore_category'=>true)).$querystring);
-                if(Mage::helper('core/url')->getCurrentUrl() != $url){
-                    Mage::app()->getFrontController()->getResponse()->setRedirect($url,301);
-                    Mage::app()->getResponse()->sendResponse();
-                }
+        if (Mage::getStoreConfig('catalog/seo/product_canonical_tag') && $this->helper->getConfig('forcecanonical')) {
+            // check for normal catalog/product/view controller here
+            if(!stristr("catalog",Mage::app()->getRequest()->getModuleName()) && Mage::app()->getRequest()->getControllerName() != "product") return;
+            // Maintain querystring if one is set (to maintain tracking URLs such as gclid)
+            $querystring = ($_SERVER['QUERY_STRING'] ? '?'.$_SERVER['QUERY_STRING'] : '');
+            $product = $observer->getEvent()->getProduct();
+            $url = Mage::helper('core/url')->escapeUrl($product->getUrlModel()->getUrl($product, array('_ignore_category'=>true)).$querystring);
+            if(Mage::helper('core/url')->getCurrentUrl() != $url){
+                Mage::app()->getFrontController()->getResponse()->setRedirect($url,301);
+                Mage::app()->getResponse()->sendResponse();
             }
         }
     }


### PR DESCRIPTION
I removed the condition `!Mage::getStoreConfig('product_use_categories'))` and unified the two `if` s into one. Why can we remove the condition?

1. The condition is currently useless, because it checks the wrong path. It would have to check `catalog/seo/product_use_categories`, so that it works. Currently, it always returns `null`, so that the condition is always evaluated to `true`.
2. The condition is counter-intuitive. If I enable the option `catalog/seo/product_canonical_tag` (which is disabled by default!) then I want the redirect to happen. No matter which other settings I made.