### PR TITLE
Making "discontinued" feature work when Flat Tables are enabled

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -87,13 +87,7 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract
 
         if ($request->getControllerName() === "product") {
 
-            $product = Mage::getResourceModel('catalog/product_collection')
-                ->addAttributeToSelect('creareseo_discontinued')
-                ->addAttributeToSelect('creareseo_discontinued_product')
-                ->addAttributeToSelect('name')
-                ->addIdFilter($request->getParam('id'))
-                ->setPageSize(1)
-                ->getFirstItem();
+            $product = Mage::getModel('catalog/product')->load($request->getParam('id'));
 
             if ($discontinuedUrl = $this->helper->getDiscontinuedProductUrl($product)) {
                 $this->redirect301($discontinuedUrl, $product->getName());
@@ -102,11 +96,7 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract
 
         if ($request->getControllerName() === "category") {
 
-            $category = Mage::getResourceModel('catalog/category_collection')
-                ->addIdFilter($request->getParam('id'))
-                ->addAttributeToSelect('name')
-                ->setPageSize(1)
-                ->getFirstItem();
+            $category = Mage::getModel('catalog/category')->load($request->getParam('id'));
 
             if ($discontinuedUrl = $this->helper->getDiscontinuedCategoryUrl($category)) {
                 $this->redirect301($discontinuedUrl, $category->getName());


### PR DESCRIPTION
Fixes #101 : A collection loaded from the flat table won't include the `creare_discontinued` attribute value or label, so instead, we must call `$model->load()`.