### PR TITLE
implemented more robust product canonical redirect, fixes #126

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Observer.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Observer.php
@@ -187,22 +187,26 @@ class Creare_CreareSeoCore_Model_Observer extends Mage_Core_Model_Abstract
 
 
     /* Checks if the page loaded is the canonical version, if not redirects to that version */
-    
+
     public function forceProductCanonical(Varien_Event_Observer $observer)
     {
-        if (Mage::getStoreConfig('catalog/seo/product_canonical_tag') && !Mage::getStoreConfig('product_use_categories'))
-        {
-            if ($this->helper->getConfig('forcecanonical')) {
-                // check for normal catalog/product/view controller here
-                if(!stristr("catalog",Mage::app()->getRequest()->getModuleName()) && Mage::app()->getRequest()->getControllerName() != "product") return;
-                // Maintain querystring if one is set (to maintain tracking URLs such as gclid)
-                $querystring = ($_SERVER['QUERY_STRING'] ? '?'.$_SERVER['QUERY_STRING'] : '');
-                $product = $observer->getEvent()->getProduct();
-                $url = Mage::helper('core/url')->escapeUrl($product->getUrlModel()->getUrl($product, array('_ignore_category'=>true)).$querystring);
-                if(Mage::helper('core/url')->getCurrentUrl() != $url){
-                    Mage::app()->getFrontController()->getResponse()->setRedirect($url,301);
-                    Mage::app()->getResponse()->sendResponse();
-                }
+        if (Mage::getStoreConfig('catalog/seo/product_canonical_tag')
+            && !Mage::getStoreConfig('product_use_categories')
+            && $this->helper->getConfig('forcecanonical')) {
+            // check for normal catalog/product/view controller here
+            if (!stristr("catalog", Mage::app()->getRequest()->getModuleName())
+                && Mage::app()->getRequest()->getControllerName() != "product") {
+                return;
+            }
+            // Maintain querystring if one is set (to maintain tracking URLs such as gclid)
+            $product    = $observer->getEvent()->getProduct();
+            $query      = Mage::app()->getRequest()->getQuery();
+            $url        = $product->getUrlModel()
+                ->getUrl($product, array('_ignore_category' => true, '_query' => $query));
+            $escapedUrl = Mage::helper('core/url')->escapeUrl($url);
+            if (Mage::helper('core/url')->getCurrentUrl() != $escapedUrl) {
+                Mage::app()->getFrontController()->getResponse()->setRedirect($url, 301);
+                Mage::app()->getResponse()->sendResponse();
             }
         }
     }


### PR DESCRIPTION
IMHO it is much cleaner to not use the `$_SERVER` global, but refer to the respective Magento methods. We have to compare with the escaped URL since `getCurrentUrl` also escapes the URL. But it makes more sense to redirect to the non-escaped version.

This should fix the redirect issue from #126. Can you confirm, @hejhog?