### PR TITLE
fixed issue with multi line product descriptions

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Block/Schema/Product.php
+++ b/app/code/community/Creare/CreareSeoCore/Block/Schema/Product.php
@@ -6,7 +6,13 @@ class Creare_CreareSeoCore_Block_Schema_Product extends Mage_Catalog_Block_Produ
 
     public function cleanString($string)
     {
-        return strip_tags(addcslashes($string, '"\\/'));
+        $cleanString = strip_tags($string);
+        $cleanString = trim($cleanString);
+        // addcslashes does NOT handle \n, so that we need to escape it ourselves
+        $cleanString = str_replace(array("\r\n", "\n"), array("\n", "\\n"), $cleanString);
+        $cleanString = addcslashes($cleanString, '"\\/');
+
+        return $cleanString;
     }
 
     public function getCurrency()


### PR DESCRIPTION
Even though we currently do a `nl2br`, new lines are still output in the JSON and therefore breaks it. `nl2br` does not replace new lines, but simply adds breaks on top of the newline characters. Additionally, `addcslashes` does not escape newline characters, so that we need to do that manually.