### PR TITLE
Update Sitemap.php

### DIFF
--- a/app/code/community/Creare/CreareSeoCore/Model/Sitemap/Sitemap.php
+++ b/app/code/community/Creare/CreareSeoCore/Model/Sitemap/Sitemap.php
@@ -32,7 +32,8 @@ class Creare_CreareSeoCore_Model_Sitemap_Sitemap extends Mage_Sitemap_Model_Site
         $categories = new Varien_Object();
         $categories->setItems($collection);
         Mage::dispatchEvent('sitemap_categories_generating_before', array(
-            'collection' => $categories
+            'collection' => $categories,
+            'store_id => $storeId
         ));
         foreach ($categories->getItems() as $item) {
             $xml = sprintf(
@@ -55,7 +56,8 @@ class Creare_CreareSeoCore_Model_Sitemap_Sitemap extends Mage_Sitemap_Model_Site
         $products = new Varien_Object();
         $products->setItems($collection);
         Mage::dispatchEvent('sitemap_products_generating_before', array(
-            'collection' => $products
+            'collection' => $products,
+            'store_id' => $storeId
         ));
         foreach ($products->getItems() as $item) {
             $xml = sprintf(


### PR DESCRIPTION
Creare_CreareSeoCore_Model_Sitemap_Sitemap method generateXml does not pass store_id when dispatching events sitemap_categories_generating_before and sitemap_products_generating_before.